### PR TITLE
changed parameter type on GifBuilder.FromGifFile to be more flexible

### DIFF
--- a/Utilities/GIFBuilder.cs
+++ b/Utilities/GIFBuilder.cs
@@ -37,9 +37,9 @@ namespace ProjectStarlight.Interchange.Utilities
 
         // https://dejanstojanovic.net/aspnet/2018/march/getting-gif-image-information-using-c/
         /// <summary>
-        ///     Creates a <see cref="TextureGIF"/> from a <see cref="FileStream"/>.
+        ///     Creates a <see cref="TextureGIF"/> from a <see cref="Stream"/>.
         /// </summary>
-        public static TextureGIF FromGIFFile(FileStream stream, GraphicsDevice graphicsDevice, int ticksPerFrame)
+        public static TextureGIF FromGIFFile(Stream stream, GraphicsDevice graphicsDevice, int ticksPerFrame)
         {
             using (Image image = Image.FromStream(stream))
             {


### PR DESCRIPTION
This should allow creating a TextureGIF from a MemoryStream aswell, which allows files to easily be loaded by TModLoader projects as they cannot get a FileStream from the .tmod file easily.